### PR TITLE
Fix use of str_contains on PHP 7

### DIFF
--- a/joubel/core/h5p.classes.php
+++ b/joubel/core/h5p.classes.php
@@ -5048,7 +5048,7 @@ class H5PContentValidator {
               // Allow certain styles
 
               // Prevent font family from getting split wrong because of the ; in &quot;
-              if (str_contains($match[1], 'font-family')) {
+              if (strpos($match[1], 'font-family') !== false) {
                 $match[1] = str_replace('&quot;', "'", $match[1]);
               }
 


### PR DESCRIPTION
When merged in, will fix crashes on moodle prior to version 4.3 running this plugin.

# Background
H5P Group used the PHP function `str_contains` in H5P core version 1.27 that this plugin uses. That function is, however, not available in PHP 7. Yes, there are people still using that despite PHP 7 has reached its end-of-life and despite not receiving any security updated anymore. In turn, users of moodle prior to version 4.3 which still supports PHP 7 may experience trouble.

There's already a [pull request for H5P core](https://github.com/h5p/h5p-php-library/pull/193), but since H5P Group is not too responsive with handling pull requests and since you're not using their code as a submodule anyway, I figure there's no reason for not patching the issue here.

Update: The master branch of H5P core already contains this change (https://github.com/h5p/h5p-php-library/commit/697facb945832ad80c55f3b611b99dbee3006edf), so it feels safe to apply it here as well now.